### PR TITLE
感染予防と相談窓口のリンクを京都府のものに差し替え

### DIFF
--- a/components/SideNavigation.vue
+++ b/components/SideNavigation.vue
@@ -76,7 +76,7 @@ export default {
         {
           icon: 'covid',
           title: this.$t('感染予防と相談窓口'),
-          link: 'https://www.pref.okayama.jp/page/644784.html'
+          link: 'https://www.pref.kyoto.jp/kentai/news/novelcoronavirus.html'
         },
         {
           icon: 'parent',


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues
- close #26 

## ⛏ 変更内容 / Details of Changes
- 感染予防と相談窓口のリンクを京都府のものに差し替え
