### PR TITLE
市町村のリンクが重複している問題を修正、日付を 2020/09/13 に修正

### DIFF
--- a/components/SideNavigation.vue
+++ b/components/SideNavigation.vue
@@ -274,11 +274,13 @@ export default Vue.extend({
           link:
             'https://www.city.muko.kyoto.jp/kurashi/soshiki/hurusatosouseisuisinnbu/kikakukouhouka/1/30/osirase/1585896380695.html',
         },
+        /*
         {
           // icon: 'mdi-chart-timeline-variant',
           title: this.$t('城陽市の情報'),
           link: 'https://www.city.joyo.kyoto.jp/category/10-0-0-0-0.html',
         },
+        */
         {
           // icon: 'mdi-chart-timeline-variant',
           title: this.$t('長岡京市の情報'),

--- a/data/news.json
+++ b/data/news.json
@@ -1,17 +1,17 @@
 {
     "newsItems": [
         {
-            "date": "2020\/08\/21",
+            "date": "2020\/09\/13",
             "url": "https:\/\/www.pref.kyoto.jp\/kentai\/corona\/hassei1-50.html",
             "text": "府内の感染状況"
         },
         {
-            "date": "2020\/08\/21",
+            "date": "2020\/09\/13",
             "url": "https:\/\/www.pref.kyoto.jp\/kentai\/corona\/pcrkensa.html",
             "text": "新型コロナウイルス感染症の府内PCR検査状況等について"
         },
         {
-            "date": "2020\/08\/21",
+            "date": "2020\/09\/13",
             "url": "http:\/\/www.pref.kyoto.jp\/kentai\/corona\/tassei_jyokyo.html",
             "text": "京都府のモニタリング指標の状況"
         }


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues
- close #492 
- close #491

## ⛏ 変更内容 / Details of Changes
- 市町村リンクダブりを削除
- 日付を最新に
