### PR TITLE
検査陽性者数の状況の右肩に日付を追加・注釈を変更

### DIFF
--- a/components/DataViewBasicInfoPanel.vue
+++ b/components/DataViewBasicInfoPanel.vue
@@ -1,10 +1,19 @@
 <template>
   <div class="DataView-DataInfo">
     <span v-if="lText !== ''" class="DataView-DataInfo-summary">
-      {{ lText }}
+      <span class="DataView-DataInfo-summary-large">
+        {{ lText }}
+      </span>
       <small class="DataView-DataInfo-summary-unit">{{ unit }}</small>
     </span>
     <br v-if="lText !== ''" />
+    <span v-if="rText !== ''" class="DataView-DataInfo-summary">
+      <span class="DataView-DataInfo-summary-regular">
+        {{ rText }}
+      </span>
+      <small class="DataView-DataInfo-summary-unit">{{ unit }}</small>
+    </span>
+    <br v-if="rText !== ''" />
     <small class="DataView-DataInfo-date">{{ sText }}</small>
     <br v-if="sTextUnder !== ''" />
     <small v-if="sTextUnder !== ''" class="DataView-DataInfo-date">{{
@@ -29,7 +38,14 @@
       font-family: Hiragino Sans, sans-serif;
       font-style: normal;
       line-height: 30px;
-      @include font-size(30);
+
+      &-large {
+        @include font-size(30);
+      }
+
+      &-regular {
+        @include font-size(20);
+      }
 
       &-unit {
         width: 100%;
@@ -54,6 +70,11 @@ import Vue from 'vue'
 export default Vue.extend({
   props: {
     lText: {
+      type: String,
+      required: false,
+      default: '',
+    },
+    rText: {
       type: String,
       required: false,
       default: '',

--- a/components/cards/ConfirmedCasesDetailsCard.vue
+++ b/components/cards/ConfirmedCasesDetailsCard.vue
@@ -6,20 +6,34 @@
         :title-id="'details-of-confirmed-cases'"
         :date="mainSummary.last_update"
       >
+        <template v-slot:infoPanel>
+          <data-view-basic-info-panel
+            :r-text="
+              $t(
+                `${
+                  confirmedCasesDate.getMonth() + 1
+                }月${confirmedCasesDate.getDate()}日の累計`
+              )
+            "
+          />
+        </template>
         <template v-slot:additionalDescription>
           <span>{{ $t('（注）') }}</span>
           <ul>
-            <li>
-              {{ $t('チャーター機帰国者、クルーズ船乗客等は含まれていない') }}
-            </li>
             <!--<li>
+              {{ $t('チャーター機帰国者、クルーズ船乗客等は含まれていない') }}
+            </li>-->
+            <li>
+              {{ $t('「調整中」には、入院先等を調整している方を計上') }}
+            </li>
+            <li>
               {{
                 $t(
                   '「重症」は、人工呼吸器管理（ECMOを含む）が必要な患者数を計上'
                 )
               }}
             </li>
-            <li>
+            <!--<li>
               {{
                 $t(
                   '退院者数の把握には一定の期間を要しており、確認次第数値を更新している'
@@ -43,23 +57,32 @@
 </template>
 
 <script>
+import inspectionsSummary from '@/data/inspections_summary.json'
 import mainSummary from '@/data/main_summary.json'
 import formatConfirmedCases from '@/utils/formatConfirmedCases'
 import DataView from '@/components/DataView.vue'
+import DataViewBasicInfoPanel from '@/components/DataViewBasicInfoPanel.vue'
 import ConfirmedCasesDetailsTable from '@/components/ConfirmedCasesDetailsTable.vue'
 // import OpenDataLink from '@/components/OpenDataLink.vue'
 
 export default {
   components: {
     DataView,
+    DataViewBasicInfoPanel,
     ConfirmedCasesDetailsTable,
     // OpenDataLink,
   },
   data() {
+    // 最新の検査日
+    const confirmedCasesDate = new Date(
+      inspectionsSummary.data[inspectionsSummary.data.length - 1]['日付']
+    )
+
     // 検査陽性者の状況
     const confirmedCases = formatConfirmedCases(mainSummary)
 
     return {
+      confirmedCasesDate,
       mainSummary,
       confirmedCases,
     }


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues
- close #1143 
- close #1142 

## ⛏ 変更内容 / Details of Changes
- 検査陽性者数の状況の右肩に日付を追加
- 検査陽性者数の状況の注釈を変更