### PR TITLE
GitHub Actionsで動かすNode.jsのバージョンを12系に上昇

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v1
         with:
-          node-version: '10.x'
+          node-version: '12.x'
 
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path

--- a/.github/workflows/deploy-data.yml
+++ b/.github/workflows/deploy-data.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v1
         with:
-          node-version: '10.x'
+          node-version: '12.x'
 
       - name: Cache dependencies
         uses: actions/cache@v1

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v1
         with:
-          node-version: '10.x'
+          node-version: '12.x'
 
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v1
         with:
-          node-version: '10.x'
+          node-version: '12.x'
 
       - name: Cache dependencies
         uses: actions/cache@v1

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v1
         with:
-          node-version: '10.x'
+          node-version: '12.x'
 
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path


### PR DESCRIPTION
<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決する issue / Resolved Issues
- close #1729

## ⛏ 変更内容 / Details of Changes
- GitHub Actionsで動かすNode.jsのバージョンを12系に上昇
