### PR TITLE
[Hotfix] deploy-data.ymlで動作するNode.jsランタイムのOld Space領域を6144MBに拡大

### DIFF
--- a/.github/workflows/deploy-data.yml
+++ b/.github/workflows/deploy-data.yml
@@ -44,6 +44,7 @@ jobs:
       - run: yarn run test
       - name: generate
         run: |
+          export NODE_OPTIONS="--max-old-space-size=6144"
           echo "GOOGLE_ANALYTICS_ID=${GOOGLE_ANALYTICS_ID}" >> .env.production
           cat .env.production
           yarn run generate:deploy --fail-on-page-error


### PR DESCRIPTION
## ⛏ 変更内容 / Details of Changes
- deploy-data.ymlで動作するNode.jsランタイムのOld Space領域を6144MBに拡大
